### PR TITLE
add wmode attribute rendering on object tag

### DIFF
--- a/npm-react-swf/react-swf.js
+++ b/npm-react-swf/react-swf.js
@@ -214,10 +214,12 @@ ReactSWF.prototype.render = function() {
   };
 
   for (var key in props) {
-    // Ignore props that are Flash parameters or managed by this component.
-    if (props.hasOwnProperty(key) &&
-        !supportedFPParamNames.hasOwnProperty(key) &&
-        !objectProps.hasOwnProperty(key)) {
+      // Ignore props that are Flash parameters or managed by this component.
+      // except for "wmode" which is needed for non-overlapping in IE
+      if (props.hasOwnProperty(key) &&
+        ((key === 'wmode') ||
+         (!supportedFPParamNames.hasOwnProperty(key) &&
+          !objectProps.hasOwnProperty(key)))) {
       objectProps[key] = props[key];
     }
   }

--- a/react-swf.js
+++ b/react-swf.js
@@ -223,9 +223,11 @@
 
     for (var key in props) {
       // Ignore props that are Flash parameters or managed by this component.
+      // except for "wmode" which is needed for non-overlapping in IE
       if (props.hasOwnProperty(key) &&
-          !supportedFPParamNames.hasOwnProperty(key) &&
-          !objectProps.hasOwnProperty(key)) {
+        ((key === 'wmode') ||
+         (!supportedFPParamNames.hasOwnProperty(key) &&
+          !objectProps.hasOwnProperty(key)))) {
         objectProps[key] = props[key];
       }
     }


### PR DESCRIPTION
Hi! Thanks for your library, it works nice.

There is a small issue.
For me in IE 10 & 11 without `wmode` attribute on object tag with value `transparent` doesn't actually work.
So could you please add this small addition?

I didn't touch `bower.json` or `npm.json`.

Thanks,
Seva